### PR TITLE
Remove visibility on Menu Layout option

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -306,7 +306,6 @@
                             <visible>Integer.IsEqual(Window.Property(CurrentFocus),9001)</visible>
                             <include>Defs_Settings_Button</include>
                             <label> - $LOCALIZE[31506]</label> <!-- Open Category Widget on Focus -->
-                            <visible>Skin.HasSetting(DisableNetflixHome) + !Skin.HasSetting(DisableNetflixCatWidget) + [!Skin.HasSetting(DisableMenuVertIcon) | Skin.HasSetting(DisableMenuVertLabel)]</visible>
                             <enable>Skin.HasSetting(DisableNetflixHome) + !Skin.HasSetting(DisableNetflixCatWidget) + [!Skin.HasSetting(DisableMenuVertIcon) | Skin.HasSetting(DisableMenuVertLabel)]</enable>
                             <selected>Skin.HasSetting(EnableCatonFocus)</selected>
                             <onclick>Skin.ToggleSetting(EnableCatonFocus)</onclick>


### PR DESCRIPTION
Remove visibility on Menu Layout option for Menu Layout `Vertical Icon w/ Labels`:
`Open Category Widget on Focus`

![2023-02-18 01_36_02-Kodi](https://user-images.githubusercontent.com/17692472/219853218-1f0ccbf5-4357-43a1-9545-60796eaf5a0a.png)

When you're in other Menu Layouts, you can still see that you have that setting selected.